### PR TITLE
Basic Verilog support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,12 @@ RUN apt-get update -qq								\
 			make build-essential g++-10				\
 			python3 python3-dev python3-pip python3-wheel		\
 			python3-numpy python3-scipy python3-matplotlib		\
-			python3-pytest python3-pytest-xdist			\
+			python3-pytest python3-pytest-forked python3-py		\
 			libfmt-dev pybind11-dev libboost-dev			\
 			libjansson-dev libgetdata-dev				\
 			libtinfo5 locales					\
 			valgrind						\
 		&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN python3.10 -m pip install pytest-check pytest-html
 
 # make /bin/sh symlink to bash instead of dash:
 RUN echo "dash dash/sh boolean false" | debconf-set-selections

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ pyxsi.so: pybind.o xsi_loader.o
 
 rtl:
 	. $(XILINX_VIVADO)/settings64.sh && \
-		xelab work.widget -prj rtl/widget.prj -debug all -dll -s widget
+		xelab work.widget -prj rtl/widget.prj -debug all -dll -s widget && \
+		xelab work.counter_verilog -prj rtl/counter.prj -debug all -dll -s counter_verilog
 
 test: pyxsi.so
 	LD_LIBRARY_PATH=$(XILINX_VIVADO)/lib/lnx64.o \

--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,12 @@ pyxsi.so: pybind.o xsi_loader.o
 rtl:
 	. $(XILINX_VIVADO)/settings64.sh && \
 		xelab work.widget -prj rtl/widget.prj -debug all -dll -s widget && \
+		xelab work.widget -prj rtl/widget.prj -debug all -dll -generic_top WIDTH=64 -s widget64 && \
 		xelab work.counter_verilog -prj rtl/counter.prj -debug all -dll -s counter_verilog  && \
 		xelab work.counter_wide_verilog -prj rtl/counter.prj -debug all -dll -s counter_wide_verilog
 
 test: pyxsi.so
-	LD_LIBRARY_PATH=$(XILINX_VIVADO)/lib/lnx64.o \
-		python3.10 -m pytest py/test.py -v
+	LD_LIBRARY_PATH=$(XILINX_VIVADO)/lib/lnx64.o py/test.py -v -s
 
 clean:
 	-rm *.o *.so

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ CXXFLAGS=-Wall -Werror -g -fPIC -std=c++20 -I/usr/include/python3.10 -I$(XILINX_
 	$(CXX) $(CXXFLAGS) -c -o $@ $<
 
 pyxsi.so: pybind.o xsi_loader.o
-	$(CXX) $(CXXFLAGS) -shared -o $@ $^ -lfmt -ldl
+	$(CXX) $(CXXFLAGS) -shared -o $@ $^ -ldl
 
 rtl:
 	. $(XILINX_VIVADO)/settings64.sh && \

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ pyxsi.so: pybind.o xsi_loader.o
 rtl:
 	. $(XILINX_VIVADO)/settings64.sh && \
 		xelab work.widget -prj rtl/widget.prj -debug all -dll -s widget && \
-		xelab work.counter_verilog -prj rtl/counter.prj -debug all -dll -s counter_verilog
+		xelab work.counter_verilog -prj rtl/counter.prj -debug all -dll -s counter_verilog  && \
+		xelab work.counter_wide_verilog -prj rtl/counter.prj -debug all -dll -s counter_wide_verilog
 
 test: pyxsi.so
 	LD_LIBRARY_PATH=$(XILINX_VIVADO)/lib/lnx64.o \

--- a/py/test.py
+++ b/py/test.py
@@ -2,13 +2,24 @@
 
 import pyxsi
 import random
+import pytest
 
 # VHDL uses 1ps timestep by default. This results in a 100 MHz clock.
 HALF_PERIOD = 5000
 
 
-def test_counting():
-    xsi = pyxsi.XSI("xsim.dir/widget/xsimk.so", is_toplevel_verilog=0, tracefile="counting.wdb")
+@pytest.mark.parametrize("language", ["VHDL", "VERILOG"])
+def test_counting(language):
+    if language == "VHDL":
+        xsi = pyxsi.XSI(
+            "xsim.dir/widget/xsimk.so", language=pyxsi.VHDL, tracefile="counting.wdb"
+        )
+    else:
+        xsi = pyxsi.XSI(
+            "xsim.dir/counter_verilog/xsimk.so",
+            language=pyxsi.VERILOG,
+            tracefile="counter_verilog.wdb",
+        )
 
     (old_a, old_b) = (f"{0:016b}", f"{0:016b}")
 
@@ -28,40 +39,18 @@ def test_counting():
 
         print(f"old_a {old_a} old_b {old_b} sum {sum} product {product}")
 
-        assert (int(old_a, 2) + int(old_b, 2)) % 2 ** 16 == int(sum, 2)
-        assert (int(old_a, 2) * int(old_b, 2)) % 2 ** 32 == int(product, 2)
+        assert (int(old_a, 2) + int(old_b, 2)) % 2**16 == int(sum, 2)
+        assert (int(old_a, 2) * int(old_b, 2)) % 2**32 == int(product, 2)
 
         (old_a, old_b) = (a, b)
 
-
-def test_counting_verilog():
-    xsi = pyxsi.XSI("xsim.dir/counter_verilog/xsimk.so", is_toplevel_verilog=1, tracefile="counter_verilog.wdb")
-
-    (old_a, old_b) = (f"{0:016b}", f"{0:016b}")
-
-    for n in range(65535 + 2):
-        xsi.set_port_value("clk", "1")
-        xsi.run(HALF_PERIOD)
-        xsi.set_port_value("clk", "0")
-        xsi.run(HALF_PERIOD)
-
-        xsi.set_port_value("a", f"{n & 0xffff:016b}")
-        xsi.set_port_value("b", f"{n & 0xffff:016b}")
-
-        a = xsi.get_port_value("a")
-        b = xsi.get_port_value("b")
-        sum = xsi.get_port_value("sum")
-        product = xsi.get_port_value("product")
-
-        print(f"old_a {old_a} old_b {old_b} sum {sum} product {product}")
-
-        assert (int(old_a, 2) + int(old_b, 2)) % 2 ** 16 == int(sum, 2)
-        assert (int(old_a, 2) * int(old_b, 2)) % 2 ** 32 == int(product, 2)
-
-        (old_a, old_b) = (a, b)
 
 def test_counting_wide_verilog():
-    xsi = pyxsi.XSI("xsim.dir/counter_wide_verilog/xsimk.so", is_toplevel_verilog=1, tracefile="counter_wide_verilog.wdb")
+    xsi = pyxsi.XSI(
+        "xsim.dir/counter_wide_verilog/xsimk.so",
+        language=pyxsi.VERILOG,
+        tracefile="counter_wide_verilog.wdb",
+    )
 
     (old_a, old_b) = (f"{0:064b}", f"{0:064b}")
 
@@ -80,15 +69,20 @@ def test_counting_wide_verilog():
         product = xsi.get_port_value("product")
 
         print(f"old_a {old_a} old_b {old_b} sum {sum} product {product}")
-        print(f"old_a {int(old_a, 2)} old_b {int(old_b, 2)} sum {int(sum,2)} product {int(product,2)}")
+        print(
+            f"old_a {int(old_a, 2)} old_b {int(old_b, 2)} sum {int(sum,2)} product {int(product,2)}"
+        )
 
-        assert (int(old_a, 2) + int(old_b, 2)) % 2 ** 64 == int(sum, 2)
-        assert (int(old_a, 2) * int(old_b, 2)) % 2 ** 128 == int(product, 2)
+        assert (int(old_a, 2) + int(old_b, 2)) % 2**64 == int(sum, 2)
+        assert (int(old_a, 2) * int(old_b, 2)) % 2**128 == int(product, 2)
 
         (old_a, old_b) = (a, b)
 
+
 def test_random():
-    xsi = pyxsi.XSI("xsim.dir/widget/xsimk.so", is_toplevel_verilog=0, tracefile="random.wdb")
+    xsi = pyxsi.XSI(
+        "xsim.dir/widget/xsimk.so", language=pyxsi.VHDL, tracefile="random.wdb"
+    )
 
     (old_a, old_b) = (f"{0:016b}", f"{0:016b}")
 
@@ -108,8 +102,8 @@ def test_random():
 
         print(f"old_a {old_a} old_b {old_b} sum {sum} product {product}")
 
-        assert (int(old_a, 2) + int(old_b, 2)) % 2 ** 16 == int(sum, 2)
-        assert (int(old_a, 2) * int(old_b, 2)) % 2 ** 32 == int(product, 2)
+        assert (int(old_a, 2) + int(old_b, 2)) % 2**16 == int(sum, 2)
+        assert (int(old_a, 2) * int(old_b, 2)) % 2**32 == int(product, 2)
 
         (old_a, old_b) = (a, b)
 

--- a/py/test.py
+++ b/py/test.py
@@ -8,7 +8,7 @@ HALF_PERIOD = 5000
 
 
 def test_counting():
-    xsi = pyxsi.XSI("xsim.dir/widget/xsimk.so", tracefile="counting.wdb")
+    xsi = pyxsi.XSI("xsim.dir/widget/xsimk.so", is_toplevel_verilog=0, tracefile="counting.wdb")
 
     (old_a, old_b) = (f"{0:016b}", f"{0:016b}")
 
@@ -34,8 +34,34 @@ def test_counting():
         (old_a, old_b) = (a, b)
 
 
+def test_counting_verilog():
+    xsi = pyxsi.XSI("xsim.dir/counter_verilog/xsimk.so", is_toplevel_verilog=1, tracefile="counter_verilog.wdb")
+
+    (old_a, old_b) = (f"{0:016b}", f"{0:016b}")
+
+    for n in range(65535 + 2):
+        xsi.set_port_value("clk", "1")
+        xsi.run(HALF_PERIOD)
+        xsi.set_port_value("clk", "0")
+        xsi.run(HALF_PERIOD)
+
+        xsi.set_port_value("a", f"{n & 0xffff:016b}")
+        xsi.set_port_value("b", f"{n & 0xffff:016b}")
+
+        a = xsi.get_port_value("a")
+        b = xsi.get_port_value("b")
+        sum = xsi.get_port_value("sum")
+        product = xsi.get_port_value("product")
+
+        print(f"old_a {old_a} old_b {old_b} sum {sum} product {product}")
+
+        assert (int(old_a, 2) + int(old_b, 2)) % 2 ** 16 == int(sum, 2)
+        assert (int(old_a, 2) * int(old_b, 2)) % 2 ** 32 == int(product, 2)
+
+        (old_a, old_b) = (a, b)
+
 def test_random():
-    xsi = pyxsi.XSI("xsim.dir/widget/xsimk.so", tracefile="random.wdb")
+    xsi = pyxsi.XSI("xsim.dir/widget/xsimk.so", is_toplevel_verilog=0, tracefile="random.wdb")
 
     (old_a, old_b) = (f"{0:016b}", f"{0:016b}")
 

--- a/py/test.py
+++ b/py/test.py
@@ -60,6 +60,33 @@ def test_counting_verilog():
 
         (old_a, old_b) = (a, b)
 
+def test_counting_wide_verilog():
+    xsi = pyxsi.XSI("xsim.dir/counter_wide_verilog/xsimk.so", is_toplevel_verilog=1, tracefile="counter_wide_verilog.wdb")
+
+    (old_a, old_b) = (f"{0:064b}", f"{0:064b}")
+
+    for n in range(2**32, (2**32) + 10):
+        xsi.set_port_value("clk", "1")
+        xsi.run(HALF_PERIOD)
+        xsi.set_port_value("clk", "0")
+        xsi.run(HALF_PERIOD)
+
+        xsi.set_port_value("a", f"{(n+1) & 0xffffffffffffff:064b}")
+        xsi.set_port_value("b", f"{(n+2) & 0xffffffffffffff:064b}")
+
+        a = xsi.get_port_value("a")
+        b = xsi.get_port_value("b")
+        sum = xsi.get_port_value("sum")
+        product = xsi.get_port_value("product")
+
+        print(f"old_a {old_a} old_b {old_b} sum {sum} product {product}")
+        print(f"old_a {int(old_a, 2)} old_b {int(old_b, 2)} sum {int(sum,2)} product {int(product,2)}")
+
+        assert (int(old_a, 2) + int(old_b, 2)) % 2 ** 64 == int(sum, 2)
+        assert (int(old_a, 2) * int(old_b, 2)) % 2 ** 128 == int(product, 2)
+
+        (old_a, old_b) = (a, b)
+
 def test_random():
     xsi = pyxsi.XSI("xsim.dir/widget/xsimk.so", is_toplevel_verilog=0, tracefile="random.wdb")
 

--- a/py/test.py
+++ b/py/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.8
+#!/usr/bin/env -S python3 -m pytest --forked
 
 import pyxsi
 import random
@@ -8,11 +8,11 @@ import pytest
 HALF_PERIOD = 5000
 
 
-@pytest.mark.parametrize("language", ["VHDL", "VERILOG"])
+@pytest.mark.parametrize("language", ["VHDL", "Verilog"])
 def test_counting(language):
     if language == "VHDL":
         xsi = pyxsi.XSI(
-            "xsim.dir/widget/xsimk.so", language=pyxsi.VHDL, tracefile="counting.wdb"
+            "xsim.dir/widget/xsimk.so", language=pyxsi.VHDL, tracefile="widget.wdb"
         )
     else:
         xsi = pyxsi.XSI(
@@ -45,12 +45,18 @@ def test_counting(language):
         (old_a, old_b) = (a, b)
 
 
-def test_counting_wide_verilog():
-    xsi = pyxsi.XSI(
-        "xsim.dir/counter_wide_verilog/xsimk.so",
-        language=pyxsi.VERILOG,
-        tracefile="counter_wide_verilog.wdb",
-    )
+@pytest.mark.parametrize("language", ["VHDL", "Verilog"])
+def test_counting_wide(language):
+    if language == "VHDL":
+        xsi = pyxsi.XSI(
+            "xsim.dir/widget64/xsimk.so", language=pyxsi.VHDL, tracefile="widget64.wdb"
+        )
+    else:
+        xsi = pyxsi.XSI(
+            "xsim.dir/counter_wide_verilog/xsimk.so",
+            language=pyxsi.VERILOG,
+            tracefile="counter_wide_verilog.wdb",
+        )
 
     (old_a, old_b) = (f"{0:064b}", f"{0:064b}")
 
@@ -79,10 +85,18 @@ def test_counting_wide_verilog():
         (old_a, old_b) = (a, b)
 
 
-def test_random():
-    xsi = pyxsi.XSI(
-        "xsim.dir/widget/xsimk.so", language=pyxsi.VHDL, tracefile="random.wdb"
-    )
+@pytest.mark.parametrize("language", ["VHDL", "Verilog"])
+def test_random(language):
+    if language == "VHDL":
+        xsi = pyxsi.XSI(
+            "xsim.dir/widget/xsimk.so", language=pyxsi.VHDL, tracefile="random_vhdl.wdb"
+        )
+    else:
+        xsi = pyxsi.XSI(
+            "xsim.dir/counter_verilog/xsimk.so",
+            language=pyxsi.VERILOG,
+            tracefile="random_verilog.wdb",
+        )
 
     (old_a, old_b) = (f"{0:016b}", f"{0:016b}")
 

--- a/rtl/counter.prj
+++ b/rtl/counter.prj
@@ -1,0 +1,1 @@
+verilog work counter.v

--- a/rtl/counter.v
+++ b/rtl/counter.v
@@ -18,7 +18,7 @@ always @ (posedge clk)
      if (rst) begin
        reg_sum <= 16'h0;
        reg_product <= 32'h0;
-     end 
+     end
      else begin
        reg_sum <= a+b;
        reg_product <= a*b;
@@ -44,7 +44,7 @@ always @ (posedge clk)
      if (rst) begin
        reg_sum <= 64'h0;
        reg_product <= 128'h0;
-     end 
+     end
      else begin
        reg_sum <= a+b;
        reg_product <= a*b;

--- a/rtl/counter.v
+++ b/rtl/counter.v
@@ -1,0 +1,27 @@
+`timescale 1 ns/1 ps
+
+module counter_verilog (clk, rst, a, b, sum, product);
+input rst, clk;
+input [15:0] a;
+input [15:0] b;
+output [15:0] sum;
+output [31:0] product;
+
+reg  [15:0] reg_sum;
+reg [31:0] reg_product;
+
+assign sum = reg_sum;
+assign product = reg_product;
+
+always @ (posedge clk)
+  begin
+     if (rst) begin
+       reg_sum <= 16'h0;
+       reg_product <= 32'h0;
+     end 
+     else begin
+       reg_sum <= a+b;
+       reg_product <= a*b;
+     end
+  end
+endmodule

--- a/rtl/counter.v
+++ b/rtl/counter.v
@@ -25,3 +25,29 @@ always @ (posedge clk)
      end
   end
 endmodule
+
+module counter_wide_verilog (clk, rst, a, b, sum, product);
+input rst, clk;
+input [63:0] a;
+input [63:0] b;
+output [63:0] sum;
+output [127:0] product;
+
+reg  [63:0] reg_sum;
+reg [127:0] reg_product;
+
+assign sum = reg_sum;
+assign product = reg_product;
+
+always @ (posedge clk)
+  begin
+     if (rst) begin
+       reg_sum <= 64'h0;
+       reg_product <= 128'h0;
+     end 
+     else begin
+       reg_sum <= a+b;
+       reg_product <= a*b;
+     end
+  end
+endmodule

--- a/rtl/widget.vhd
+++ b/rtl/widget.vhd
@@ -2,11 +2,13 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-entity widget is port (
+entity widget is
+generic (WIDTH : natural := 16);
+port (
     clk, rst : in std_logic := '0';
-    a, b     : in unsigned(15 downto 0):= 16ux"0";
-    sum      : out unsigned(15 downto 0) := 16ux"0";
-    product  : out unsigned(31 downto 0) := 32ux"0");
+    a, b     : in unsigned(WIDTH-1 downto 0):= (others => '0');
+    sum      : out unsigned(WIDTH-1 downto 0) := (others => '0');
+    product  : out unsigned(2*WIDTH-1 downto 0) := (others => '0'));
 end widget;
 
 architecture behav of widget is

--- a/src/pybind.cpp
+++ b/src/pybind.cpp
@@ -1,6 +1,7 @@
 #include <unordered_map>
 #include <algorithm>
 #include <optional>
+#include <iostream>
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -24,16 +25,89 @@ const char SLV_DASH=8;
 
 enum class PortDirection {INPUT, OUTPUT, INOUT};
 
+size_t roundup_int_div(size_t dividend, size_t divisor) {
+	return (dividend + divisor - 1) / divisor;
+}
+
+void clear_bit(XSI_UINT32 &container, size_t ind) {
+	container = container & ~((XSI_UINT32)1 << ind);	
+}
+
+void set_bit(XSI_UINT32 &container, size_t ind) {
+	container = container | ((XSI_UINT32)1 << ind);	
+}
+
+bool test_bit(XSI_UINT32 &container, size_t ind) {
+	return ((container & ((XSI_UINT32)1 << ind)) > 0 ? true : false);
+}
+
+void set_logic_val_at_ind(s_xsi_vlog_logicval &logicval, size_t ind, char val) {
+	switch(val) {
+		case '0':
+			clear_bit((logicval.aVal), ind);
+			clear_bit((logicval.bVal), ind);
+			break;
+		case '1':
+			set_bit((logicval.aVal), ind);
+			clear_bit((logicval.bVal), ind);
+			break;
+		case 'X':
+			set_bit((logicval.aVal), ind);
+			set_bit((logicval.bVal), ind);
+			break;
+		case 'Z':
+			clear_bit((logicval.aVal), ind);
+			set_bit((logicval.bVal), ind);
+			break;
+		default:
+			throw std::runtime_error("Unrecognized value for set_logic_val_at_ind: "+val);
+	}
+}
+
+void string_to_logic_val(std::string str, s_xsi_vlog_logicval* value) {
+	size_t str_len = str.length();
+	size_t num_words = roundup_int_div(str_len, 32);
+	memset(value, 0, sizeof(s_xsi_vlog_logicval)*num_words);
+	for(size_t i = 0; i < str_len; i++) {
+		size_t array_ind = i / 32;
+		size_t bit_ind = i % 32;
+		set_logic_val_at_ind(value[array_ind], bit_ind, str[str_len-i-1]);
+	}
+}
+
+std::string logic_val_to_string(s_xsi_vlog_logicval* value, size_t n_bits) {
+	std::string ret(n_bits, '?');
+	for(size_t i = 0; i < n_bits; i++) {
+		size_t array_ind = i / 32;
+		size_t bit_ind = i % 32;
+		bool is_set_aVal = test_bit(value[array_ind].aVal, bit_ind);
+		bool is_set_bVal = test_bit(value[array_ind].bVal, bit_ind);
+		if(!is_set_aVal && !is_set_bVal) {
+			ret[n_bits-i-1] = '0';
+		} else if(is_set_aVal && !is_set_bVal) {
+			ret[n_bits-i-1] = '1';
+		} else if(!is_set_aVal && is_set_bVal) {
+			ret[n_bits-i-1] = 'X';
+		} else {
+			ret[n_bits-i-1] = 'Z';
+		}
+	}
+	//std::cout << "logic_val_to_string logicval.a=" << std::hex << value[0].aVal << " logicval.b=" << value[0].bVal << " retstr " << ret << std::dec << std::endl;
+	return ret;
+}
+
 class XSI {
 	public:
 		XSI(
 				const std::string &design_so,
 				const std::string &simengine_so="librdi_simulator_kernel.so",
+				const int is_toplevel_verilog=0,
 				const std::optional<std::string> &tracefile=std::nullopt,
 				const std::optional<std::string> &logfile=std::nullopt)
 			:
 				design_so(design_so),
 				simengine_so(simengine_so),
+				is_toplevel_verilog(is_toplevel_verilog),
 				tracefile(tracefile),
 				logfile(logfile)
 		{
@@ -80,6 +154,22 @@ class XSI {
 
 		virtual ~XSI() = default;
 
+		void close() {
+			loader->close();
+		}
+
+		void restart() {
+			loader->restart();
+		}
+
+		const int get_status() {
+			return loader->get_status();
+		}
+
+		const std::string get_error_info() {
+			return loader->get_error_info();
+		} 
+
 		void run(int const& duration) {
 			loader->run(duration);
 		}
@@ -92,29 +182,39 @@ class XSI {
 			return loader->get_str_property_port(index, xsiNameTopPort);
 		}
 
+		const int get_is_toplevel_verilog() const {
+			return is_toplevel_verilog;
+		}
+
 		const std::string get_port_value(std::string const& port_name) const {
 			auto const& [port, length, direction] = port_map.at(port_name);
-
-			/* Create a vector of chars and receive the value into it
-			 * (get_value does not allocate space) */
-			std::string s(length, '0');
-			loader->get_value(port, s.data());
-
-			/* Transform into a string we can sanely deal with */
-			std::transform(std::begin(s), std::end(s), std::begin(s), [](auto const& ch) {
-				switch(ch) {
-					case SLV_0: return '0';
-					case SLV_1: return '1';
-					case SLV_U: return 'U';
-					case SLV_X: return 'X';
-					case SLV_Z: return 'Z';
-					case SLV_W: return 'W';
-					case SLV_L: return 'L';
-					case SLV_H: return 'H';
-					case SLV_DASH: return '-';
-					default: return 'X';
-				}});
-			return s;
+			if(is_toplevel_verilog) {
+				s_xsi_vlog_logicval *logicval = new s_xsi_vlog_logicval[roundup_int_div(length, 32)];
+				loader->get_value(port, logicval);
+				std::string ret = logic_val_to_string(logicval, length);
+				delete [] logicval;
+				return ret;
+			} else {
+				/* Create a vector of chars and receive the value into it
+				* (get_value does not allocate space) */
+				std::string s(length, '0');
+				loader->get_value(port, s.data());
+				/* Transform into a string we can sanely deal with */
+				std::transform(std::begin(s), std::end(s), std::begin(s), [](auto const& ch) {
+					switch(ch) {
+						case SLV_0: return '0';
+						case SLV_1: return '1';
+						case SLV_U: return 'U';
+						case SLV_X: return 'X';
+						case SLV_Z: return 'Z';
+						case SLV_W: return 'W';
+						case SLV_L: return 'L';
+						case SLV_H: return 'H';
+						case SLV_DASH: return '-';
+						default: return 'X';
+					}});
+				return s;
+			}
 		}
 
 		void set_port_value(std::string const& port_name, std::string value) {
@@ -123,7 +223,13 @@ class XSI {
 			if(length != value.length())
 				throw std::invalid_argument("Length of vector didn't match length of port!");
 
-			std::transform(std::begin(value), std::end(value), std::begin(value), [](auto const& ch) {
+			if(is_toplevel_verilog) {
+				s_xsi_vlog_logicval *logicval = new s_xsi_vlog_logicval[roundup_int_div(length, 32)];
+				string_to_logic_val(value, logicval);
+				loader->put_value(port, logicval);
+				delete [] logicval;
+			} else {
+				std::transform(std::begin(value), std::end(value), std::begin(value), [](auto const& ch) {
 				switch(ch) {
 					case '0': return SLV_0;
 					case '1': return SLV_1;
@@ -136,8 +242,8 @@ class XSI {
 					case '-': return SLV_DASH;
 					default: return SLV_X;
 				}});
-
-			loader->put_value(port, value.data());
+				loader->put_value(port, value.data());
+			}
 		}
 
 	private:
@@ -146,6 +252,7 @@ class XSI {
 
 		const std::string design_so;
 		const std::string simengine_so;
+		const int is_toplevel_verilog;
 		const std::optional<std::string> tracefile;
 		const std::optional<std::string> logfile;
 
@@ -155,9 +262,10 @@ class XSI {
 
 PYBIND11_MODULE(pyxsi, m) {
 	py::class_<XSI>(m, "XSI")
-		.def(py::init<std::string const&, std::string const&, std::optional<std::string> const&, std::optional<std::string> const&>(),
+		.def(py::init<std::string const&, std::string const&, int, std::optional<std::string> const&, std::optional<std::string> const&>(),
 				py::arg("design_so"),
 				py::arg("simengine_so")="librdi_simulator_kernel.so",
+				py::arg("is_toplevel_verilog")=0,
 				py::arg("tracefile")=std::nullopt,
 				py::arg("logfile")=std::nullopt)
 
@@ -165,6 +273,11 @@ PYBIND11_MODULE(pyxsi, m) {
 		.def("set_port_value", &XSI::set_port_value)
 		.def("get_port_count", &XSI::get_port_count)
 		.def("get_port_name", &XSI::get_port_name)
+		.def("close", &XSI::close)
+		.def("restart", &XSI::restart)
+		.def("get_status", &XSI::get_status)
+		.def("get_error_info", &XSI::get_error_info)
+		.def("get_is_toplevel_verilog", &XSI::get_is_toplevel_verilog)
 		.def("run", &XSI::run, py::arg("duration")=0);
 }
 

--- a/src/pybind.cpp
+++ b/src/pybind.cpp
@@ -191,10 +191,9 @@ class XSI {
 
 			switch(language) {
 				case Language::VERILOG: {
-					s_xsi_vlog_logicval *logicval = new s_xsi_vlog_logicval[roundup_int_div(length, 32)];
-					loader->get_value(port, logicval);
-					std::string ret = logic_val_to_string(logicval, length);
-					delete [] logicval;
+					auto logicval = std::vector<s_xsi_vlog_logicval>(roundup_int_div(length, 32));
+					loader->get_value(port, logicval.data());
+					std::string ret = logic_val_to_string(logicval.data(), length);
 					return ret;
 				}
 
@@ -233,10 +232,9 @@ class XSI {
 
 			switch(language) {
 				case Language::VERILOG: {
-					s_xsi_vlog_logicval *logicval = new s_xsi_vlog_logicval[roundup_int_div(length, 32)];
-					string_to_logic_val(value, logicval);
-					loader->put_value(port, logicval);
-					delete [] logicval;
+					auto logicval = std::vector<s_xsi_vlog_logicval>(roundup_int_div(length, 32));
+					string_to_logic_val(value, logicval.data());
+					loader->put_value(port, logicval.data());
 					break;
 				}
 

--- a/src/pybind.cpp
+++ b/src/pybind.cpp
@@ -6,6 +6,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#define FMT_HEADER_ONLY
 #include <fmt/format.h>
 
 #include "xsi_loader.h"

--- a/src/pybind.cpp
+++ b/src/pybind.cpp
@@ -214,7 +214,7 @@ class XSI {
 							case SLV_L: return 'L';
 							case SLV_H: return 'H';
 							case SLV_DASH: return '-';
-							default: return 'X';
+							default: throw std::runtime_error("Unexpected logic value!");
 						}});
 					return s;
 				}
@@ -250,7 +250,7 @@ class XSI {
 						case 'L': return SLV_L;
 						case 'H': return SLV_H;
 						case '-': return SLV_DASH;
-						default: return SLV_X;
+						default: throw std::runtime_error("Unexpected logic value!");
 					}});
 					loader->put_value(port, value.data());
 					break;

--- a/src/pybind.cpp
+++ b/src/pybind.cpp
@@ -84,6 +84,14 @@ class XSI {
 			loader->run(duration);
 		}
 
+		const int get_port_count() const {
+			return loader->num_ports();
+		}
+
+		const std::string get_port_name(int index) const {
+			return loader->get_str_property_port(index, xsiNameTopPort);
+		}
+
 		const std::string get_port_value(std::string const& port_name) const {
 			auto const& [port, length, direction] = port_map.at(port_name);
 
@@ -155,6 +163,8 @@ PYBIND11_MODULE(pyxsi, m) {
 
 		.def("get_port_value", &XSI::get_port_value)
 		.def("set_port_value", &XSI::set_port_value)
+		.def("get_port_count", &XSI::get_port_count)
+		.def("get_port_name", &XSI::get_port_name)
 		.def("run", &XSI::run, py::arg("duration")=0);
 }
 


### PR DESCRIPTION
Fixes #5 

Introduces basic support for Verilog top-level modules. Different setter/getter functions are used for Verilog (as opposed to VHDL) top-level modules, therefore the `is_toplevel_verilog` argument must be correctly set when the sim object is being initialized, e.g. `xsi = pyxsi.XSI("xsim.dir/counter_verilog/xsimk.so", is_toplevel_verilog=1, tracefile="counter_verilog.wdb")`. 

Also introduces two Verilog testcases, one which is a simple Verilog reimplementation of the VHDL counter example, and the other with wide inputs and outputs to ensure wide-bit-vector cases also work correctly. 

Finally, while working on this feature I found it useful to expose a few more functions from XSI to the Python side and added those to the bindings:

```
		.def("get_port_count", &XSI::get_port_count)
		.def("get_port_name", &XSI::get_port_name)
		.def("close", &XSI::close)
		.def("restart", &XSI::restart)
		.def("get_status", &XSI::get_status)
		.def("get_error_info", &XSI::get_error_info)
		.def("get_is_toplevel_verilog", &XSI::get_is_toplevel_verilog)
```